### PR TITLE
feat: use configured registry when building exploit images

### DIFF
--- a/crates/kriger/src/cli/commands/deploy.rs
+++ b/crates/kriger/src/cli/commands/deploy.rs
@@ -46,7 +46,7 @@ async fn build_image(
 
     for (key, value) in build_args {
         args.push("--build-arg".into());
-        args.push(Cow::Owned(format!("{}={}", key, value)));
+        args.push(format!("{}={}", key, value).into());
     }
 
     args.push(".".into());


### PR DESCRIPTION
We want to respect the user's configured registry when building exploit images for kriger.

Changes:
* Use users kriger config for setting docker registry when building exploits
 